### PR TITLE
Add moved in and moved out statuses to blips

### DIFF
--- a/spec/models/blip-spec.js
+++ b/spec/models/blip-spec.js
@@ -32,7 +32,7 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
-      true
+      'new'
     )
 
     expect(blip.isNew()).toBe(true)
@@ -42,9 +42,69 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
-      false
+      'unchanged'
     )
 
     expect(blip.isNew()).toBe(false)
+  })
+
+  it('is moved in', function () {
+    blip = new Blip(
+      'My Blip',
+      new Ring('My Ring'),
+      'moved_in'
+    )
+
+    expect(blip.isMovedIn()).toBe(true)
+  })
+
+  it('is not moved in', function () {
+    blip = new Blip(
+      'My Blip',
+      new Ring('My Ring'),
+      'unchanged'
+    )
+
+    expect(blip.isMovedIn()).toBe(false)
+  })
+
+  it('is moved out', function () {
+    blip = new Blip(
+      'My Blip',
+      new Ring('My Ring'),
+      'moved_out'
+    )
+
+    expect(blip.isMovedOut()).toBe(true)
+  })
+
+  it('is not moved out', function () {
+    blip = new Blip(
+      'My Blip',
+      new Ring('My Ring'),
+      'unchanged'
+    )
+
+    expect(blip.isMovedOut()).toBe(false)
+  })
+
+  it('is unchanged', function () {
+    blip = new Blip(
+      'My Blip',
+      new Ring('My Ring'),
+      'unchanged'
+    )
+
+    expect(blip.isUnchanged()).toBe(true)
+  })
+
+  it('is not unchanged', function () {
+    blip = new Blip(
+      'My Blip',
+      new Ring('My Ring'),
+      'new'
+    )
+
+    expect(blip.isUnchanged()).toBe(false)
   })
 })

--- a/spec/util/contentValidator-spec.js
+++ b/spec/util/contentValidator-spec.js
@@ -5,7 +5,7 @@ const ExceptionMessages = require('../../src/util/exceptionMessages')
 describe('ContentValidator', function () {
   describe('verifyContent', function () {
     it('does not return anything if content is valid', function () {
-      var columnNames = ['name', 'ring', 'quadrant', 'isNew', 'description']
+      var columnNames = ['name', 'ring', 'quadrant', 'status', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyContent()).not.toBeDefined()
@@ -23,7 +23,7 @@ describe('ContentValidator', function () {
 
   describe('verifyHeaders', function () {
     it('raises an error if one of the headers is empty', function () {
-      var columnNames = ['ring', 'quadrant', 'isNew', 'description']
+      var columnNames = ['ring', 'quadrant', 'status', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(function () {
@@ -32,14 +32,14 @@ describe('ContentValidator', function () {
     })
 
     it('does not return anything if the all required headers are present', function () {
-      var columnNames = ['name', 'ring', 'quadrant', 'isNew', 'description']
+      var columnNames = ['name', 'ring', 'quadrant', 'status', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyHeaders()).not.toBeDefined()
     })
 
     it('does not care about white spaces in the headers', function () {
-      var columnNames = [' name', 'ring ', '   quadrant', 'isNew   ', '   description   ']
+      var columnNames = [' name', 'ring ', '   quadrant', 'status   ', '   description   ']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyHeaders()).not.toBeDefined()

--- a/spec/util/inputSanitizer-spec.js
+++ b/spec/util/inputSanitizer-spec.js
@@ -11,7 +11,7 @@ describe('InputSanitizer', function () {
       description: description,
       ring: '<a href="/asd">Adopt</a>',
       quadrant: '<strong>techniques and tools</strong>',
-      isNew: 'true<br>'
+      status: 'new<br>'
     }
 
     blip = sanitizer.sanitize(rawBlip)
@@ -26,7 +26,7 @@ describe('InputSanitizer', function () {
   })
 
   it('strips out all tags from blip status', function () {
-    expect(blip.isNew).toEqual('true')
+    expect(blip.status).toEqual('new')
   })
 
   it('strips out all tags from blip ring', function () {
@@ -57,7 +57,7 @@ describe('Input Santizer for Protected sheet', function () {
       'name',
       'quadrant',
       'ring',
-      'isNew',
+      'status',
       'description'
     ]
 
@@ -65,7 +65,7 @@ describe('Input Santizer for Protected sheet', function () {
       "Hello <script>alert('dangerous');</script>there <h1>blip</h1>",
       '<strong>techniques & tools</strong>',
       "<a href='/asd'>Adopt</a>",
-      'true<br>',
+      'new<br>',
       "<b>Hello</b> <script>alert('dangerous');</script>there <h1>heading</h1>"
     ]
 
@@ -81,7 +81,7 @@ describe('Input Santizer for Protected sheet', function () {
   })
 
   it('strips out all tags from blip status', function () {
-    expect(blip.isNew).toEqual('true')
+    expect(blip.status).toEqual('new')
   })
 
   it('strips out all tags from blip ring', function () {

--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -105,25 +105,45 @@ const Radar = function (size, radar) {
     })
   }
 
-  function triangle (blip, x, y, order, group) {
+  function newBlip (blip, x, y, order, group) {
     return group.append('path').attr('d', 'M412.201,311.406c0.021,0,0.042,0,0.063,0c0.067,0,0.135,0,0.201,0c4.052,0,6.106-0.051,8.168-0.102c2.053-0.051,4.115-0.102,8.176-0.102h0.103c6.976-0.183,10.227-5.306,6.306-11.53c-3.988-6.121-4.97-5.407-8.598-11.224c-1.631-3.008-3.872-4.577-6.179-4.577c-2.276,0-4.613,1.528-6.48,4.699c-3.578,6.077-3.26,6.014-7.306,11.723C402.598,306.067,405.426,311.406,412.201,311.406')
       .attr('transform', 'scale(' + (blip.width / 34) + ') translate(' + (-404 + x * (34 / blip.width) - 17) + ', ' + (-282 + y * (34 / blip.width) - 17) + ')')
       .attr('class', order)
   }
 
-  function triangleLegend (x, y, group) {
+  function newLegend (x, y, group) {
     return group.append('path').attr('d', 'M412.201,311.406c0.021,0,0.042,0,0.063,0c0.067,0,0.135,0,0.201,0c4.052,0,6.106-0.051,8.168-0.102c2.053-0.051,4.115-0.102,8.176-0.102h0.103c6.976-0.183,10.227-5.306,6.306-11.53c-3.988-6.121-4.97-5.407-8.598-11.224c-1.631-3.008-3.872-4.577-6.179-4.577c-2.276,0-4.613,1.528-6.48,4.699c-3.578,6.077-3.26,6.014-7.306,11.723C402.598,306.067,405.426,311.406,412.201,311.406')
       .attr('transform', 'scale(' + (22 / 64) + ') translate(' + (-404 + x * (64 / 22) - 17) + ', ' + (-282 + y * (64 / 22) - 17) + ')')
   }
 
-  function circle (blip, x, y, order, group) {
+  function movedInBlip (blip, x, y, order, group) {
+    // TODO: replace this with moved in specific shap instead of re-usign new
+    return newBlip(blip, x, y, order, group);
+  }
+
+  function movedInLegend (x, y, group) {
+    // TODO: replace this with moved in specific shap instead of re-usign new
+    return newLegend(x, y, group);
+  }
+
+  function movedOutBlip (blip, x, y, order, group) {
+    // TODO: replace this with moved out specific shap instead of re-usign new
+    return newBlip(blip, x, y, order, group);
+  }
+
+  function movedOutLegend (x, y, group) {
+    // TODO: replace this with moved out specific shap instead of re-usign new
+    return newLegend(x, y, group);
+  }
+
+  function unchangedBlip (blip, x, y, order, group) {
     return (group || svg).append('path')
       .attr('d', 'M420.084,282.092c-1.073,0-2.16,0.103-3.243,0.313c-6.912,1.345-13.188,8.587-11.423,16.874c1.732,8.141,8.632,13.711,17.806,13.711c0.025,0,0.052,0,0.074-0.003c0.551-0.025,1.395-0.011,2.225-0.109c4.404-0.534,8.148-2.218,10.069-6.487c1.747-3.886,2.114-7.993,0.913-12.118C434.379,286.944,427.494,282.092,420.084,282.092')
       .attr('transform', 'scale(' + (blip.width / 34) + ') translate(' + (-404 + x * (34 / blip.width) - 17) + ', ' + (-282 + y * (34 / blip.width) - 17) + ')')
       .attr('class', order)
   }
 
-  function circleLegend (x, y, group) {
+  function unchangedLegend (x, y, group) {
     return (group || svg).append('path')
       .attr('d', 'M420.084,282.092c-1.073,0-2.16,0.103-3.243,0.313c-6.912,1.345-13.188,8.587-11.423,16.874c1.732,8.141,8.632,13.711,17.806,13.711c0.025,0,0.052,0,0.074-0.003c0.551-0.025,1.395-0.011,2.225-0.109c4.404-0.534,8.148-2.218,10.069-6.487c1.747-3.886,2.114-7.993,0.913-12.118C434.379,286.944,427.494,282.092,420.084,282.092')
       .attr('transform', 'scale(' + (22 / 64) + ') translate(' + (-404 + x * (64 / 22) - 17) + ', ' + (-282 + y * (64 / 22) - 17) + ')')
@@ -238,9 +258,13 @@ const Radar = function (size, radar) {
     var group = quadrantGroup.append('g').attr('class', 'blip-link').attr('id', 'blip-link-' + blip.number())
 
     if (blip.isNew()) {
-      triangle(blip, x, y, order, group)
-    } else {
-      circle(blip, x, y, order, group)
+      newBlip(blip, x, y, order, group)
+    } else if (blip.isMovedIn()) {
+      movedInBlip(blip, x, y, order, group)
+    } else if (blip.isMovedOut()) {
+      movedOutBlip(blip, x, y, order, group)
+    } else { // unchanged
+      unchangedBlip(blip, x, y, order, group)
     }
 
     group.append('text')
@@ -320,8 +344,10 @@ const Radar = function (size, radar) {
   function drawLegend (order) {
     removeRadarLegend()
 
-    var triangleKey = 'New or moved'
-    var circleKey = 'No change'
+    var newKey = 'New'
+    var movedInKey = 'Moved In'
+    var movedOutKey = 'Moved Out'
+    var unchangedKey = 'No change'
 
     var container = d3.select('svg').append('g')
       .attr('class', 'legend legend' + '-' + order)
@@ -354,23 +380,41 @@ const Radar = function (size, radar) {
       .transition()
       .style('visibility', 'visible')
 
-    triangleLegend(x, y, container)
+    newLegend(x, y, container)
 
     container
       .append('text')
       .attr('x', x + 15)
       .attr('y', y + 5)
       .attr('font-size', '0.8em')
-      .text(triangleKey)
+      .text(newKey)
 
-    circleLegend(x, y + 20, container)
+    movedInLegend(x, y + 20, container)
 
     container
       .append('text')
       .attr('x', x + 15)
       .attr('y', y + 25)
       .attr('font-size', '0.8em')
-      .text(circleKey)
+      .text(movedInKey)
+
+    movedOutLegend(x, y + 40, container)
+
+    container
+      .append('text')
+      .attr('x', x + 15)
+      .attr('y', y + 45)
+      .attr('font-size', '0.8em')
+      .text(movedOutKey)
+
+    unchangedLegend(x, y + 60, container)
+
+    container
+      .append('text')
+      .attr('x', x + 15)
+      .attr('y', y + 65)
+      .attr('font-size', '0.8em')
+      .text(unchangedKey)
   }
 
   function redrawFullRadar () {

--- a/src/models/blip.js
+++ b/src/models/blip.js
@@ -1,5 +1,13 @@
 const IDEAL_BLIP_WIDTH = 22
-const Blip = function (name, ring, isNew, topic, description) {
+
+const STATUSES = {
+  NEW: 'new',
+  MOVED_IN: 'moved_in',
+  MOVED_OUT: 'moved_out',
+  UNCHANGED: 'unchanged',
+}
+
+const Blip = function (name, ring, status, topic, description) {
   var self, number
 
   self = {}
@@ -20,7 +28,19 @@ const Blip = function (name, ring, isNew, topic, description) {
   }
 
   self.isNew = function () {
-    return isNew
+    return status === STATUSES.NEW
+  }
+
+  self.isMovedIn = function () {
+    return status === STATUSES.MOVED_IN
+  }
+
+  self.isMovedOut = function () {
+    return status === STATUSES.MOVED_OUT
+  }
+
+  self.isUnchanged = function () {
+    return status === STATUSES.UNCHANGED
   }
 
   self.ring = function () {

--- a/src/util/contentValidator.js
+++ b/src/util/contentValidator.js
@@ -21,7 +21,7 @@ const ContentValidator = function (columnNames) {
   }
 
   self.verifyHeaders = function () {
-    _.each(['name', 'ring', 'quadrant', 'isNew', 'description'], function (field) {
+    _.each(['name', 'ring', 'quadrant', 'status', 'description'], function (field) {
       if (columnNames.indexOf(field) === -1) {
         throw new MalformedDataError(ExceptionMessages.MISSING_HEADERS)
       }

--- a/src/util/exceptionMessages.js
+++ b/src/util/exceptionMessages.js
@@ -2,7 +2,7 @@ const ExceptionMessages = {
   TOO_MANY_QUADRANTS: 'There are more than 4 quadrant names listed in your data. Check the quadrant column for errors.',
   TOO_MANY_RINGS: 'More than 5 rings.',
   MISSING_HEADERS: 'Document is missing one or more required headers or they are misspelled. ' +
-  'Check that your document contains headers for "name", "ring", "quadrant", "isNew", "description".',
+  'Check that your document contains headers for "name", "ring", "quadrant", "status", "description".',
   MISSING_CONTENT: 'Document is missing content.',
   LESS_THAN_FOUR_QUADRANTS: 'There are less than 4 quadrant names listed in your data. Check the quadrant column for errors.',
   SHEET_NOT_FOUND: 'Oops! We can’t find the Google Sheet you’ve entered. Can you check the URL?',

--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -46,7 +46,7 @@ const plotRadar = function (title, blips, currentRadarName, alternativeRadars) {
     if (!quadrants[blip.quadrant]) {
       quadrants[blip.quadrant] = new Quadrant(_.capitalize(blip.quadrant))
     }
-    quadrants[blip.quadrant].add(new Blip(blip.name, ringMap[blip.ring], blip.isNew.toLowerCase() === 'true', blip.topic, blip.description))
+    quadrants[blip.quadrant].add(new Blip(blip.name, ringMap[blip.ring], blip.status, blip.topic, blip.description))
   })
 
   var radar = new Radar()

--- a/src/util/inputSanitizer.js
+++ b/src/util/inputSanitizer.js
@@ -33,7 +33,7 @@ const InputSanitizer = function () {
     var blip = trimWhiteSpaces(rawBlip)
     blip.description = sanitizeHtml(blip.description, relaxedOptions)
     blip.name = sanitizeHtml(blip.name, restrictedOptions)
-    blip.isNew = sanitizeHtml(blip.isNew, restrictedOptions)
+    blip.status = sanitizeHtml(blip.status, restrictedOptions)
     blip.ring = sanitizeHtml(blip.ring, restrictedOptions)
     blip.quadrant = sanitizeHtml(blip.quadrant, restrictedOptions)
 
@@ -45,19 +45,19 @@ const InputSanitizer = function () {
 
     const descriptionIndex = header.indexOf('description')
     const nameIndex = header.indexOf('name')
-    const isNewIndex = header.indexOf('isNew')
+    const statusIndex = header.indexOf('status')
     const quadrantIndex = header.indexOf('quadrant')
     const ringIndex = header.indexOf('ring')
 
     const description = descriptionIndex === -1 ? '' : blip[descriptionIndex]
     const name = nameIndex === -1 ? '' : blip[nameIndex]
-    const isNew = isNewIndex === -1 ? '' : blip[isNewIndex]
+    const status = statusIndex === -1 ? '' : blip[statusIndex]
     const ring = ringIndex === -1 ? '' : blip[ringIndex]
     const quadrant = quadrantIndex === -1 ? '' : blip[quadrantIndex]
 
     blip.description = sanitizeHtml(description, relaxedOptions)
     blip.name = sanitizeHtml(name, restrictedOptions)
-    blip.isNew = sanitizeHtml(isNew, restrictedOptions)
+    blip.status = sanitizeHtml(status, restrictedOptions)
     blip.ring = sanitizeHtml(ring, restrictedOptions)
     blip.quadrant = sanitizeHtml(quadrant, restrictedOptions)
 


### PR DESCRIPTION
* This mirrors what Thoughtworks have on their own radar rather than
  what's offered from the build-your-own-radar.
* Currently, the moved in and out blips are rendered using the new
  rounded triangle shape, but I've left `TODO` comments for where we
  need to define the actual SVG shapes for these.
* With SWG shapes defined in those 4 functions, we should then be able to
  see the four different shapes on the radar and in the key/legend.
* It's an open question as to whether we try to replicate the partial
  halos for these used by Thoughtworks, or whether we just use different
  shapes. The partial halos would be nice but require quadrant
  knowledge in order to plot correctly.