### PR TITLE
Remove the form for the Google sheet URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ The project has [`jasmine`](https://jasmine.github.io/) for testing.
     make test
 
 Runs the full test suite.
+
+### Data
+
+The data is pulled from a the [Kyan Tech Radar](https://docs.google.com/spreadsheets/d/1zlxGZkmyFkxjH71HwsbRZ4WCrGCia2uj5W3orc8ewyg) google sheet.
+
+If you need to work from a different sheet for development purposes, first make a copy of the sheet, then publish to the web, then update the `sheetUrl` variable in [`src/util/factory.js](./src/util/factory.js).

--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -4,7 +4,6 @@ const Chance = require('chance')
 const _ = require('lodash/core')
 
 const RingCalculator = require('../util/ringCalculator')
-const QueryParams = require('../util/queryParamProcessor')
 const AutoComplete = require('../util/autoComplete')
 
 const MIN_BLIP_WIDTH = 12
@@ -619,8 +618,7 @@ const Radar = function (size, radar) {
 
   function constructSheetUrl (sheetName) {
     var noParamUrl = window.location.href.substring(0, window.location.href.indexOf(window.location.search))
-    var queryParams = QueryParams(window.location.search.substring(1))
-    var sheetUrl = noParamUrl + '?sheetId=' + queryParams.sheetId + '&sheetName=' + encodeURIComponent(sheetName)
+    var sheetUrl = noParamUrl + '?sheetName=' + encodeURIComponent(sheetName)
     return sheetUrl
   }
 


### PR DESCRIPTION
* Remove the form for the sheet URL as for our purposes we will always
  be using the same sheet.
* Also remove support for CSV files, as we'll always works from Google
  sheet.
* Retain support for switching between different tabs in the sheet, as
  we'll want to use this in future when we publish updated radars.