### PR TITLE
Add department to blips and colour code

### DIFF
--- a/spec/models/blip-spec.js
+++ b/spec/models/blip-spec.js
@@ -7,7 +7,8 @@ describe('Blip', function () {
   beforeEach(function () {
     blip = new Blip(
       'My Blip',
-      new Ring('My Ring')
+      new Ring('My Ring'),
+      'foo_department'
     )
   })
 
@@ -28,10 +29,15 @@ describe('Blip', function () {
     expect(blip.number()).toEqual(1)
   })
 
+  it('has a department', function () {
+    expect(blip.department()).toEqual('foo_department')
+  })
+
   it('is new', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
+      'engineering',
       'new'
     )
 
@@ -42,6 +48,7 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
+      'engineering',
       'unchanged'
     )
 
@@ -52,6 +59,7 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
+      'engineering',
       'moved_in'
     )
 
@@ -62,6 +70,7 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
+      'engineering',
       'unchanged'
     )
 
@@ -72,6 +81,7 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
+      'engineering',
       'moved_out'
     )
 
@@ -82,6 +92,7 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
+      'engineering',
       'unchanged'
     )
 
@@ -92,6 +103,7 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
+      'engineering',
       'unchanged'
     )
 
@@ -102,6 +114,7 @@ describe('Blip', function () {
     blip = new Blip(
       'My Blip',
       new Ring('My Ring'),
+      'engineering',
       'new'
     )
 

--- a/spec/util/contentValidator-spec.js
+++ b/spec/util/contentValidator-spec.js
@@ -5,7 +5,7 @@ const ExceptionMessages = require('../../src/util/exceptionMessages')
 describe('ContentValidator', function () {
   describe('verifyContent', function () {
     it('does not return anything if content is valid', function () {
-      var columnNames = ['name', 'ring', 'quadrant', 'status', 'description']
+      var columnNames = ['name', 'ring', 'quadrant', 'department', 'status', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyContent()).not.toBeDefined()
@@ -23,7 +23,7 @@ describe('ContentValidator', function () {
 
   describe('verifyHeaders', function () {
     it('raises an error if one of the headers is empty', function () {
-      var columnNames = ['ring', 'quadrant', 'status', 'description']
+      var columnNames = ['ring', 'quadrant', 'department', 'status', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(function () {
@@ -32,14 +32,14 @@ describe('ContentValidator', function () {
     })
 
     it('does not return anything if the all required headers are present', function () {
-      var columnNames = ['name', 'ring', 'quadrant', 'status', 'description']
+      var columnNames = ['name', 'ring', 'quadrant', 'department', 'status', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyHeaders()).not.toBeDefined()
     })
 
     it('does not care about white spaces in the headers', function () {
-      var columnNames = [' name', 'ring ', '   quadrant', 'status   ', '   description   ']
+      var columnNames = [' name', 'ring ', '   quadrant', ' department ', 'status   ', '   description   ']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyHeaders()).not.toBeDefined()

--- a/spec/util/inputSanitizer-spec.js
+++ b/spec/util/inputSanitizer-spec.js
@@ -57,6 +57,7 @@ describe('Input Santizer for Protected sheet', function () {
       'name',
       'quadrant',
       'ring',
+      'department',
       'status',
       'description'
     ]
@@ -65,6 +66,7 @@ describe('Input Santizer for Protected sheet', function () {
       "Hello <script>alert('dangerous');</script>there <h1>blip</h1>",
       '<strong>techniques & tools</strong>',
       "<a href='/asd'>Adopt</a>",
+      '<b>engineering</b>',
       'new<br>',
       "<b>Hello</b> <script>alert('dangerous');</script>there <h1>heading</h1>"
     ]

--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -107,7 +107,7 @@ const Radar = function (size, radar) {
   function newBlip (blip, x, y, order, group) {
     return group.append('path').attr('d', 'M412.201,311.406c0.021,0,0.042,0,0.063,0c0.067,0,0.135,0,0.201,0c4.052,0,6.106-0.051,8.168-0.102c2.053-0.051,4.115-0.102,8.176-0.102h0.103c6.976-0.183,10.227-5.306,6.306-11.53c-3.988-6.121-4.97-5.407-8.598-11.224c-1.631-3.008-3.872-4.577-6.179-4.577c-2.276,0-4.613,1.528-6.48,4.699c-3.578,6.077-3.26,6.014-7.306,11.723C402.598,306.067,405.426,311.406,412.201,311.406')
       .attr('transform', 'scale(' + (blip.width / 34) + ') translate(' + (-404 + x * (34 / blip.width) - 17) + ', ' + (-282 + y * (34 / blip.width) - 17) + ')')
-      .attr('class', order)
+      .attr('class', blip.department)
   }
 
   function newLegend (x, y, group) {
@@ -139,7 +139,7 @@ const Radar = function (size, radar) {
     return (group || svg).append('path')
       .attr('d', 'M420.084,282.092c-1.073,0-2.16,0.103-3.243,0.313c-6.912,1.345-13.188,8.587-11.423,16.874c1.732,8.141,8.632,13.711,17.806,13.711c0.025,0,0.052,0,0.074-0.003c0.551-0.025,1.395-0.011,2.225-0.109c4.404-0.534,8.148-2.218,10.069-6.487c1.747-3.886,2.114-7.993,0.913-12.118C434.379,286.944,427.494,282.092,420.084,282.092')
       .attr('transform', 'scale(' + (blip.width / 34) + ') translate(' + (-404 + x * (34 / blip.width) - 17) + ', ' + (-282 + y * (34 / blip.width) - 17) + ')')
-      .attr('class', order)
+      .attr('class', blip.department)
   }
 
   function unchangedLegend (x, y, group) {

--- a/src/models/blip.js
+++ b/src/models/blip.js
@@ -7,7 +7,13 @@ const STATUSES = {
   UNCHANGED: 'unchanged',
 }
 
-const Blip = function (name, ring, status, topic, description) {
+const DEPARTMENTS = {
+  ENGINEERING: 'Engineering',
+  DESIGN: 'Design',
+  QA: 'QA',
+}
+
+const Blip = function (name, ring, department, status, topic, description) {
   var self, number
 
   self = {}
@@ -25,6 +31,10 @@ const Blip = function (name, ring, status, topic, description) {
 
   self.description = function () {
     return description || ''
+  }
+
+  self.department = function () {
+    return department
   }
 
   self.isNew = function () {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -214,23 +214,18 @@ body {
       }
 
       circle, polygon, path {
-        &.first {
+        &.engineering {
           fill: $green;
           stroke: none;
         }
 
-        &.second {
+        &.design {
           fill: $blue;
           stroke: none;
         }
 
-        &.third {
+        &.qa {
           fill: $orange;
-          stroke: none;
-        }
-
-        &.fourth {
-          fill: $violet;
           stroke: none;
         }
       }

--- a/src/util/contentValidator.js
+++ b/src/util/contentValidator.js
@@ -21,7 +21,7 @@ const ContentValidator = function (columnNames) {
   }
 
   self.verifyHeaders = function () {
-    _.each(['name', 'ring', 'quadrant', 'status', 'description'], function (field) {
+    _.each(['name', 'ring', 'quadrant', 'department', 'status', 'description'], function (field) {
       if (columnNames.indexOf(field) === -1) {
         throw new MalformedDataError(ExceptionMessages.MISSING_HEADERS)
       }

--- a/src/util/exceptionMessages.js
+++ b/src/util/exceptionMessages.js
@@ -2,7 +2,7 @@ const ExceptionMessages = {
   TOO_MANY_QUADRANTS: 'There are more than 4 quadrant names listed in your data. Check the quadrant column for errors.',
   TOO_MANY_RINGS: 'More than 5 rings.',
   MISSING_HEADERS: 'Document is missing one or more required headers or they are misspelled. ' +
-  'Check that your document contains headers for "name", "ring", "quadrant", "status", "description".',
+  'Check that your document contains headers for "name", "ring", "quadrant", "department", "status", "description".',
   MISSING_CONTENT: 'Document is missing content.',
   LESS_THAN_FOUR_QUADRANTS: 'There are less than 4 quadrant names listed in your data. Check the quadrant column for errors.',
   SHEET_NOT_FOUND: 'Oops! We can’t find the Google Sheet you’ve entered. Can you check the URL?',

--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -48,7 +48,7 @@ const plotRadar = function (title, blips, currentRadarName, alternativeRadars) {
     if (!quadrants[blip.quadrant]) {
       quadrants[blip.quadrant] = new Quadrant(_.capitalize(blip.quadrant))
     }
-    quadrants[blip.quadrant].add(new Blip(blip.name, ringMap[blip.ring], blip.status, blip.topic, blip.description))
+    quadrants[blip.quadrant].add(new Blip(blip.name, ringMap[blip.ring], blip.department, blip.status, blip.topic, blip.description))
   })
 
   var radar = new Radar()

--- a/src/util/inputSanitizer.js
+++ b/src/util/inputSanitizer.js
@@ -33,6 +33,7 @@ const InputSanitizer = function () {
     var blip = trimWhiteSpaces(rawBlip)
     blip.description = sanitizeHtml(blip.description, relaxedOptions)
     blip.name = sanitizeHtml(blip.name, restrictedOptions)
+    blip.department = sanitizeHtml(blip.department, restrictedOptions)
     blip.status = sanitizeHtml(blip.status, restrictedOptions)
     blip.ring = sanitizeHtml(blip.ring, restrictedOptions)
     blip.quadrant = sanitizeHtml(blip.quadrant, restrictedOptions)
@@ -45,18 +46,21 @@ const InputSanitizer = function () {
 
     const descriptionIndex = header.indexOf('description')
     const nameIndex = header.indexOf('name')
+    const departmentIndex = header.indexOf('department')
     const statusIndex = header.indexOf('status')
     const quadrantIndex = header.indexOf('quadrant')
     const ringIndex = header.indexOf('ring')
 
     const description = descriptionIndex === -1 ? '' : blip[descriptionIndex]
     const name = nameIndex === -1 ? '' : blip[nameIndex]
+    const department = departmentIndex === -1 ? '' : blip[departmentIndex]
     const status = statusIndex === -1 ? '' : blip[statusIndex]
     const ring = ringIndex === -1 ? '' : blip[ringIndex]
     const quadrant = quadrantIndex === -1 ? '' : blip[quadrantIndex]
 
     blip.description = sanitizeHtml(description, relaxedOptions)
     blip.name = sanitizeHtml(name, restrictedOptions)
+    blip.department = sanitizeHtml(department, restrictedOptions)
     blip.status = sanitizeHtml(status, restrictedOptions)
     blip.ring = sanitizeHtml(ring, restrictedOptions)
     blip.quadrant = sanitizeHtml(quadrant, restrictedOptions)


### PR DESCRIPTION
* The Thoughtworks radar uses colours on the blips to indicate
  quadrants.
* We want to use colours to indicate departments.
* This introduces the concept of the department to the blips and updates
  the styling to use a different colour for each rather than quadrant.
* Still to do:
  * Add a key for the department colours
  * Update the quadrant navigation buttons to remove the colours.