### PR TITLE
Use the department colours on the radar blips

### DIFF
--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -216,17 +216,17 @@ body {
 
       circle, polygon, path {
         &.engineering {
-          fill: $green;
+          fill: $engineering-blue;
           stroke: none;
         }
 
         &.design {
-          fill: $blue;
+          fill: $design-green;
           stroke: none;
         }
 
         &.qa {
-          fill: $orange;
+          fill: $qa-pink;
           stroke: none;
         }
       }


### PR DESCRIPTION
* PR #7 introduced the final colours for the Kyan radar departments and
  a key displaying them.
* This applies those colours to the radar blips correctly.