### PR TITLE
Tidy blip item descriptions in the sidebar

### DIFF
--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -327,7 +327,7 @@ const Radar = function (size, radar) {
       .attr('id', 'blip-description-' + blip.number())
       .attr('class', 'blip-item-description')
     if (blip.description()) {
-      blipItemDescription.append('p').html(blip.description())
+      blipItemDescription.append('div').html(blip.description())
     }
 
     var mouseOver = function () {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -349,11 +349,14 @@ h1, h2, h3, h4, h5 {
             overflow: hidden;
             width: 300px;
 
+            > div {
+              border-top: 1px solid $grey;
+              border-bottom: 1px solid $grey;
+              margin: 20px 0;
+              padding: 0 10px;
+            }
+
             p {
-              margin: 0;
-              border-top: 1px solid rgb(119, 119, 119);
-              border-bottom: 1px solid rgb(119, 119, 119);
-              padding: 20px;
               color: $grey-text;
               font-weight: 100;
               font-size: 14px;


### PR DESCRIPTION
* The top and bottom borders and spacing are currently based off of
  `<p>` tags which is problematic for content.
* This tidies that up.

![image](https://user-images.githubusercontent.com/1125251/127521451-37eefd25-60c8-41fb-bc08-bbf01519011a.png)
