### PR TITLE
Increase radar axis width

### DIFF
--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -54,12 +54,12 @@ const Radar = function (size, radar) {
     quadrantGroup.append('line')
       .attr('x1', center()).attr('x2', center())
       .attr('y1', startY - 2).attr('y2', endY + 2)
-      .attr('stroke-width', 10)
+      .attr('stroke-width', 30)
 
     quadrantGroup.append('line')
       .attr('x1', endX).attr('y1', center())
       .attr('x2', startX).attr('y2', center())
-      .attr('stroke-width', 10)
+      .attr('stroke-width', 30)
   }
 
   function plotQuadrant (rings, quadrant) {
@@ -218,7 +218,7 @@ const Radar = function (size, radar) {
     var radius = chance.floating({ min: minRadius + blip.width / 2, max: maxRadius - blip.width / 2 })
     var angleDelta = Math.asin(blip.width / 2 / radius) * 180 / Math.PI
     angleDelta = angleDelta > 45 ? 45 : angleDelta
-    var angle = toRadian(chance.integer({ min: angleDelta, max: 90 - angleDelta }))
+    var angle = toRadian(chance.integer({ min: angleDelta + 3, max: 90 - angleDelta - 3 }))
 
     var x = center() + radius * Math.cos(angle) * adjustX
     var y = center() + radius * Math.sin(angle) * adjustY

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -251,10 +251,8 @@ h1, h2, h3, h4, h5 {
         }
 
         &.line-text {
-          font-weight: bold;
-          text-transform: uppercase;
           fill: $black;
-          font-size: 7px;
+          font-size: 14px;
         }
       }
     }


### PR DESCRIPTION
* Increases the radar axis width from 10 to 30px.
* Increase the font-size and drop the shouty all caps.
* Also adds a 3px nudge on the angle in the blip placing calculation to
  reduce the likelihood of blips overlapping the axis.
* This has fixed the majority, as it effectively adds a padding to the
  edges of the quadrants - but not at the centre as the angle has no
  effect there - but I haven't been able to crack that yet. That'll
  likely need a similar adjust on the minimum radius, but ideally only
  for the inner ring.

![image](https://user-images.githubusercontent.com/1125251/127622151-a07efdf2-f6cd-4bca-983b-bbf4195a1d2d.png)
