### PR TITLE
Fix error being displayed in footer

### DIFF
--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -757,8 +757,6 @@ const Radar = function (size, radar) {
       plotTexts(quadrantGroup, rings, quadrant)
       plotBlips(quadrantGroup, rings, quadrant)
     })
-
-    plotRadarFooter()
   }
 
   return self

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -170,7 +170,7 @@ h1, h2, h3, h4, h5 {
 
   #radar {
     width: 80%;
-    margin: 0 auto;
+    margin: 0 auto 128px auto;
     position: relative;
 
     svg#radar-plot {


### PR DESCRIPTION
* The error message is being displayed in the footer because we're
  trying to call the plotFooterBanner function that's been removed.
* This corrects that and adds some margin to the bottom of the rader so
  that it's not butting up right against the bottom of the browser when
  there's no footer.