### PR TITLE
Tidy up and general tweaks for real data

### DIFF
--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -203,11 +203,14 @@ const Radar = function (size, radar) {
 
   function addRing (name, description, order) {
     var table = d3.select('.quadrant-table.' + order)
-    table.append('h3')
-      .text(name)
-      .append('span')
-      .attr('data-tippy-content', description)
-      .text('?')
+    var heading = table.append('h3').text(name)
+
+    if (description) {
+      heading.append('span')
+        .attr('data-tippy-content', description)
+        .text('?')
+    }
+
     return table.append('ul')
   }
 
@@ -218,7 +221,7 @@ const Radar = function (size, radar) {
     var radius = chance.floating({ min: minRadius + blip.width / 2, max: maxRadius - blip.width / 2 })
     var angleDelta = Math.asin(blip.width / 2 / radius) * 180 / Math.PI
     angleDelta = angleDelta > 45 ? 45 : angleDelta
-    var angle = toRadian(chance.integer({ min: angleDelta + 3, max: 90 - angleDelta - 3 }))
+    var angle = toRadian(chance.integer({ min: angleDelta + 2, max: 90 - angleDelta - 2 }))
 
     var x = center() + radius * Math.cos(angle) * adjustX
     var y = center() + radius * Math.sin(angle) * adjustY
@@ -330,7 +333,7 @@ const Radar = function (size, radar) {
       .attr('y', y + 4)
       .attr('class', 'blip-text')
       // derive font-size from current blip width
-      .style('font-size', ((blip.width * 10) / 22) + 'px')
+      .style('font-size', ((blip.width * 10) / 28) + 'px')
       .attr('text-anchor', 'middle')
       .text(blip.number())
 
@@ -415,12 +418,12 @@ const Radar = function (size, radar) {
 
     if (order === 'first') {
       x = 4 * size / 5
-      y = 1 * size / 5
+      y = 1 * size / 5 - 80
     }
 
     if (order === 'second') {
       x = 1 * size / 5 - 15
-      y = 1 * size / 5 - 20
+      y = 1 * size / 5 - 80
     }
 
     if (order === 'third') {
@@ -538,6 +541,8 @@ const Radar = function (size, radar) {
       .append('div')
       .attr('class', 'radar-title__logo')
       .html('<img src="/images/kyan.svg" />')
+      .style('cursor', 'pointer')
+      .on('click', redrawFullRadar)
 
     header.select('.radar-title')
       .append('div')

--- a/src/models/blip.js
+++ b/src/models/blip.js
@@ -1,4 +1,4 @@
-const IDEAL_BLIP_WIDTH = 28
+const IDEAL_BLIP_WIDTH = 20
 
 const STATUSES = {
   NEW: 'new',

--- a/src/models/ring.js
+++ b/src/models/ring.js
@@ -2,11 +2,11 @@ const Ring = function (name, order) {
   var self = {}
 
   const DESCRIPTIONS = {
-    'Core': "Central to the work we do at Kyan. Can be used on any project.",
-    'Adopt': "Under the right circumstances, we think this is ready for client projects.",
-    'Trial': "We've assessed this and think it's worth trialing on a small, low risk project. Internal projects are ideal.",
-    'Assess': "We're interested in understanding whether this is something worth trialing. A typical assessment might be a 'hello world' and a dev talk.",
-    'Hold': "It's likely we've found an alternative that we prefer for new projects, or there are concerns about whether this is right for Kyan."
+    'core': "Central to the work we do at Kyan. Can be used on any project.",
+    'adopt': "Under the right circumstances, we think this is ready for client projects.",
+    'trial': "We've assessed this and think it's worth trialing on a small, low risk project. Internal projects are ideal.",
+    'assess': "We're interested in understanding whether this is something worth trialing. A typical assessment might be a 'hello world' and a dev talk.",
+    'hold': "It's likely we've found an alternative that we prefer for new projects, or there are concerns about whether this is right for Kyan."
   }
 
   self.name = function () {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -259,12 +259,13 @@ a:hover {
         &.blip-text {
           font-size: 9px;
           fill: $white;
-          transform: translateX(-1px) translateY(-1px);
+          transform: translateX(-0.5px) translateY(-2px);
         }
 
         &.line-text {
           fill: $black;
           font-size: 14px;
+          text-transform: capitalize;
         }
       }
     }

--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -230,6 +230,8 @@ function plotErrorMessage (exception) {
     message = message.concat(exception.message)
   } else if (exception instanceof SheetNotFoundError) {
     message = exception.message
+  } else if (exception instanceof RangeError) {
+    message = "Your window is too small to render the data. Please enlarge the window size and refresh."
   } else {
     console.error(exception)
   }


### PR DESCRIPTION
* Reduce blip size to accomodate 116 blips from real data.
* Only output sidebar ring tooltips if a description is available.
* Define proper ring description copy for tooltips.
* Reduce the angleDelta nudge to make more room for blips.
* Move the top quandrant legends slighlty further from radar.
* Add a click handler to the Kyan logo to go to 'home'
* Nudge the blip text positioning to re-centre for reduced size.
* Add a more helpful error message if the radar errors due to
  insufficient window space to plot the blips.